### PR TITLE
사이즈에 따라 밈 크기 다르게 렌더링

### DIFF
--- a/src/components/Meme/index.tsx
+++ b/src/components/Meme/index.tsx
@@ -1,10 +1,11 @@
-import React, { useMemo } from 'react';
-import Text from '../Text';
-import { DEFALUT_IMAGE } from '../../constants';
-import ProfileImage from '../ProfileImage';
-import Frame, { FloatBox, Footer, MemeFrame } from './styles';
-import { randomInt } from '../../utils/math';
-import { Link } from 'react-router-dom';
+import React, { useMemo } from "react";
+import Text from "../Text";
+import { DEFALUT_IMAGE } from "../../constants";
+import ProfileImage from "../ProfileImage";
+import Frame, { FloatBox, Footer, MemeFrame } from "./styles";
+import { randomInt } from "../../utils/math";
+import { Link } from "react-router-dom";
+import { DefaultTheme } from "styled-components/dist/types";
 
 interface MemeProps {
   imageURL?: string;
@@ -12,7 +13,7 @@ interface MemeProps {
   owner: string;
   ownerProfileURL?: string;
   position: Position;
-  size: Meme['size'];
+  size: Meme["size"];
   memeId: string;
 }
 
@@ -30,26 +31,37 @@ const Meme: React.FC<MemeProps> = ({
     if (hasImage) {
       return <img src={imageURL} alt={text} />;
     } else if (hasText) {
-      return <Text size="detail">{text}</Text>;
+      return <Text size={textSizeMap[size]}>{text}</Text>;
     } else {
       return <img src={DEFALUT_IMAGE} alt={text} />;
     }
-  }, [imageURL, text]);
+  }, [imageURL, text, size]);
 
   const animationDelay = useMemo(() => randomInt(1000, 0, 100), []);
+
   return (
-    <Link to={'/detail'} state={{ memeId }}>
+    <Link to={"/detail"} state={{ memeId }}>
       <Frame data-ref="meme" position={position} size={size}>
         <FloatBox delay={animationDelay}>
           <MemeFrame>{meme}</MemeFrame>
           <Footer>
-            <ProfileImage imageURL={ownerProfileURL} />
-            <Text size="detail">{owner}</Text>
+            <ProfileImage imageURL={ownerProfileURL} size={size} />
+            <Text size={textSizeMap[size]}>{owner}</Text>
           </Footer>
         </FloatBox>
       </Frame>
     </Link>
   );
+};
+
+const textSizeMap: {
+  L: keyof DefaultTheme["typography"];
+  M: keyof DefaultTheme["typography"];
+  S: keyof DefaultTheme["typography"];
+} = {
+  L: "detail1",
+  M: "detail2",
+  S: "detail3",
 };
 
 export default Meme;

--- a/src/components/Meme/styles.tsx
+++ b/src/components/Meme/styles.tsx
@@ -1,24 +1,28 @@
-import styled from 'styled-components';
-import { typo, themeColor } from '../../utils/style';
-import { MEME_WIDTH_BY_SIZE } from '../../constants';
+import styled from "styled-components";
+import { typo, themeColor } from "../../utils/style";
+import { MEME_WIDTH_BY_SIZE } from "../../constants";
 
-export default styled.div.attrs<{ position: Position, size: Meme['size'] }>(({ size, position }) => ({
-  style: {
-    width: MEME_WIDTH_BY_SIZE[size] + 'px',
-    transform: `translate(${position.x}px, -${position.y}px)`,
-  },
-}))`
-  ${typo('body')}
-  color: ${themeColor('text')};
+export default styled.div.attrs<{ position: Position; size: Meme["size"] }>(
+  ({ size, position }) => ({
+    style: {
+      width: MEME_WIDTH_BY_SIZE[size] + "px",
+      transform: `translate(${position.x}px, -${position.y}px)`,
+    },
+  })
+)`
+  ${typo("body")}
+  color: ${themeColor("text")};
   border-radius: 4px;
   position: absolute;
-  transition: transform 3s linear;
+  transition: transform 1s linear;
   bottom: 0;
 `;
 
 export const FloatBox = styled.div.attrs<{ delay: number }>(({ delay }) => ({
   style: {
-    animation: `6s linear ${delay}ms infinite ${delay % 2 === 0 ? '' : 'reverse'} float`
+    animation: `6s linear ${delay}ms infinite ${
+      delay % 2 === 0 ? "" : "reverse"
+    } float`,
   },
 }))`
   background: #fff;

--- a/src/components/ProfileImage/index.tsx
+++ b/src/components/ProfileImage/index.tsx
@@ -1,18 +1,25 @@
-import React, { useMemo } from 'react'
-import { DEFALUT__PROFILE_IMAGE } from '../../constants';
-import Frame from './styles';
+import React, { useMemo } from "react";
+import {
+  DEFALUT__PROFILE_IMAGE,
+  MEME_PROFILE_WIDTH_BY_SIZE,
+} from "../../constants";
+import Frame from "./styles";
 
 interface ProfileImageProps {
   imageURL?: string;
+  size: "S" | "M" | "L";
 }
 
-const ProfileImage: React.FC<ProfileImageProps> = ({ imageURL }) => {
-  const image = useMemo(() => imageURL !== undefined ? imageURL : DEFALUT__PROFILE_IMAGE, [imageURL]);
+const ProfileImage: React.FC<ProfileImageProps> = ({ imageURL, size }) => {
+  const image = useMemo(
+    () => (imageURL !== undefined ? imageURL : DEFALUT__PROFILE_IMAGE),
+    [imageURL]
+  );
   return (
-    <Frame>
+    <Frame size={MEME_PROFILE_WIDTH_BY_SIZE[size]}>
       <img src={image} alt="user profile" />
     </Frame>
-  )
-}
+  );
+};
 
 export default ProfileImage;

--- a/src/components/ProfileImage/styles.tsx
+++ b/src/components/ProfileImage/styles.tsx
@@ -1,14 +1,13 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
-export default styled.div`
-  display: inline-block;
-  border-radius: 50%;
-  overflow: hidden;
-  width: 24px;
-  height: 24px;
+export default styled.div<{ size: number }>`
+  width: ${({ size }) => size}px;
+  height: ${({ size }) => size}px;
 
   img {
+    display: block;
     width: 100%;
     height: 100%;
+    border-radius: 50%;
   }
 `;

--- a/src/components/Text/styles.tsx
+++ b/src/components/Text/styles.tsx
@@ -1,33 +1,35 @@
-import styled, { DefaultTheme } from 'styled-components';
-import { typo, themeColor } from '../../utils/style';
+import styled, { DefaultTheme } from "styled-components";
+import { typo, themeColor } from "../../utils/style";
 
 export interface TextStyleProps {
-  size: keyof DefaultTheme['typography'];
+  size: keyof DefaultTheme["typography"];
   type?: keyof typeof typeMap;
-  color?: keyof DefaultTheme['color'];
-};
+  color?: keyof DefaultTheme["color"];
+}
 
 export default styled.span<TextStyleProps>`
   ${({ size }) => typo(size)};
 
   display: ${({ type, size }) => {
     if (type !== undefined) return typeMap[type];
-    switch (size){
-      case 'body':
-      case 'detail':
+    switch (size) {
+      case "body":
+      case "detail1":
+      case "detail2":
+      case "detail3":
         return typeMap.inline;
-      case 'heading1':
-      case 'heading2':
-      case 'heading3':
-      case 'heading4':
+      case "heading1":
+      case "heading2":
+      case "heading3":
+      case "heading4":
         return typeMap.block;
     }
   }};
 
-  color: ${({ color, theme }) => themeColor(color ?? 'text')({ theme })};
+  color: ${({ color, theme }) => themeColor(color ?? "text")({ theme })};
 `;
 
 const typeMap = {
-  inline: 'inline-block',
-  block: 'block',
+  inline: "inline-block",
+  block: "block",
 } as const;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,8 +1,14 @@
-export const DEFALUT_IMAGE = 'https://dummyimage.com/600x400/000/fff';
-export const DEFALUT__PROFILE_IMAGE = 'https://dummyimage.com/600x400/000/fff';
+export const DEFALUT_IMAGE = "https://dummyimage.com/600x400/000/fff";
+export const DEFALUT__PROFILE_IMAGE = "https://dummyimage.com/600x400/000/fff";
 
-export const MEME_WIDTH_BY_SIZE: Record<Meme['size'], number> = {
-  S: 80,
+export const MEME_WIDTH_BY_SIZE: Record<Meme["size"], number> = {
+  S: 100,
   M: 150,
   L: 200,
+};
+
+export const MEME_PROFILE_WIDTH_BY_SIZE: Record<Meme["size"], number> = {
+  S: 16,
+  M: 20,
+  L: 24,
 };

--- a/src/hooks/queries/useMemes.ts
+++ b/src/hooks/queries/useMemes.ts
@@ -9,39 +9,42 @@ const useMemes = () => {
     QUERY_KEY.MEMES,
     () =>
       new Promise((res) =>
-        socketIO.on(SOCKET_MESSAGE.FETCH_MEMES, (memesRaw: MemeRaw[]) => {
-          const memes = (memesRaw ?? []).map<Meme>((meme) => {
-            let size: keyof typeof MEME_WIDTH_BY_SIZE;
+        socketIO.on(SOCKET_MESSAGE.FETCH_MEMES, (memeRaws: MemeRaw[][]) => {
+          const memesTimeLine = (memeRaws ?? []).map<Meme[]>((memes) =>
+            memes.map((meme) => {
+              let size: keyof typeof MEME_WIDTH_BY_SIZE;
 
-            if (meme.distance < 300) {
-              size = "L";
-            } else if (meme.distance < 1000) {
-              size = "M";
-            } else {
-              size = "S";
-            }
+              if (meme.distance < 300) {
+                size = "L";
+              } else if (meme.distance < 1000) {
+                size = "M";
+              } else {
+                size = "S";
+              }
 
-            return {
-              id: meme.memeId,
-              owner: meme.nickname,
-              ownerId: meme.creator,
-              updatorId: meme.updater,
-              createdTime: meme.createdTs,
-              updatedTime: meme.updatedTs,
-              ownerProfileURL: meme.profileImg,
-              size,
-              imageURL: meme.imgUrl,
-              text: meme.message,
-              stickers: meme.stickers,
-            };
-          });
-          res(memes);
+              return {
+                id: meme.memeId,
+                owner: meme.nickname,
+                ownerId: meme.creator,
+                updatorId: meme.updater,
+                createdTime: meme.createdTs,
+                updatedTime: meme.updatedTs,
+                ownerProfileURL: meme.profileImg,
+                size,
+                imageURL: meme.imgUrl,
+                text: meme.message,
+                stickers: meme.stickers,
+              };
+            })
+          );
+
+          res(memesTimeLine);
         })
       )
   );
 
   return {
-    memes: data as Meme[],
+    memesTimeLine: data as Meme[][],
     isLoading,
   };
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,17 +16,15 @@ const root = ReactDOM.createRoot(
 const queryClient = new QueryClient();
 
 root.render(
-  <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <SocketProvider>
-        <CookiesProvider>
-          <ThemeProvider theme={theme}>
-            <App />
-          </ThemeProvider>
-        </CookiesProvider>
-      </SocketProvider>
-    </QueryClientProvider>
-  </React.StrictMode>
+  <QueryClientProvider client={queryClient}>
+    <SocketProvider>
+      <CookiesProvider>
+        <ThemeProvider theme={theme}>
+          <App />
+        </ThemeProvider>
+      </CookiesProvider>
+    </SocketProvider>
+  </QueryClientProvider>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/pages/Main/MemeList/index.tsx
+++ b/src/pages/Main/MemeList/index.tsx
@@ -35,14 +35,12 @@ const MemeList: React.FC<MemeListProps> = ({ memesTimeLine }) => {
       memesTimeLine.flat().map((meme) => ({
         ...meme,
         position: {
-          x:
-            meme.position?.x ??
-            getXCoord(
-              meme.createdTime % getContainerWidth(),
-              getContainerWidth(),
-              meme.size,
-              memes
-            ),
+          x: getXCoord(
+            meme.createdTime % getContainerWidth(),
+            getContainerWidth(),
+            meme.size,
+            memesTimeLine.flat()
+          ),
           y:
             getTimeDiffBetweenNowAnd(meme.createdTime) *
             getHeightOffsetPerSec(),

--- a/src/pages/Main/MemeList/index.tsx
+++ b/src/pages/Main/MemeList/index.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import Container from './styles';
-import Meme from '../../../components/Meme';
-import { formatMemes } from './meta';
-import { useInterval, useWindowSize } from 'react-use';
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import Container from "./styles";
+import Meme from "../../../components/Meme";
+import { formatMemes } from "./meta";
+import { useInterval } from "react-use";
 
 interface MemeListProps {
   memes: Meme[];
@@ -12,77 +12,90 @@ const MemeList: React.FC<MemeListProps> = ({ memes }) => {
   const [hasRenderedFirst, setHasRenderedFirst] = useState(false);
   const [_memes, setMemes] = useState<Meme[]>([]);
   const containerRef = useRef<HTMLDivElement>(null);
-  const { width, height }= useWindowSize();
 
   useInterval(() => {
     if (_memes.length === 0 || !hasRenderedFirst) return;
+
     const containerElement = containerRef.current;
+
     if (!containerElement) return;
-    setMemes((prev) => {
-      return [...prev].map((meme) => {
+
+    setMemes((prev) =>
+      prev.map((meme) => {
         if (!meme.position) return meme;
+
         const { x, y } = meme.position;
+
         return { ...meme, position: { x, y: y + 9 } };
-      });
-    });
+      })
+    );
   }, 3000);
-  
+
   useLayoutEffect(() => {
     if (memes.length === 0) return;
+
     if (!hasRenderedFirst) {
       setHasRenderedFirst(true);
     }
+
     let memeElements: Element[] = [];
+
     const containerElement = containerRef.current;
+
     if (containerElement) {
       memeElements = Array.from<Element>(
         containerElement.querySelectorAll('[data-ref="meme"]')
       );
     }
-    const newMemes = formatMemes(memes, memeElements);
+
+    const containerWidth = containerElement?.getBoundingClientRect()
+      .width as number;
+
+    const newMemes = formatMemes(memes, memeElements, containerWidth);
+
     setMemes(newMemes);
   }, [memes, hasRenderedFirst]);
 
-  useLayoutEffect(() => {
-    const containerElement = containerRef.current;
-    if (!containerElement) return;
-    const memeElements = Array.from<Element>(
-      containerElement.querySelectorAll('[data-ref="meme"]')
-    );
-    const oldestMemeHeight =
-      memeElements.at(-1)?.getBoundingClientRect().height ?? 0;
-    const oldestMemeY = _memes.at(-1)?.position?.y;
-    const containerHeight = oldestMemeY
-      ? oldestMemeY + oldestMemeHeight + 'px'
-      : '100vh';
-    containerElement.style.setProperty('height', containerHeight);
-  }, [_memes]);
-
   useEffect(() => {
     if (_memes.length === 0 || !hasRenderedFirst) return;
+
     const containerElement = containerRef.current;
+
     if (!containerElement) return;
+
     const timer = setTimeout(() => {
-      containerElement.classList.remove('init');
+      containerElement.classList.remove("init");
     }, 0);
+
     return () => {
       clearTimeout(timer);
-    }
+    };
   }, [_memes, hasRenderedFirst]);
 
   return (
     <Container ref={containerRef} className="init">
-      {_memes.map(({ id, owner, ownerProfileURL, imageURL, text, position = { x: 0, y: 0 }, createdTime, size }) => 
-        <Meme
-        key={id}
-        imageURL={imageURL}
-        text={text}
-        owner={owner}
-        ownerProfileURL={ownerProfileURL}
-        position={position}
-        size={size}
+      {_memes.map(
+        ({
+          id,
+          owner,
+          ownerProfileURL,
+          imageURL,
+          text,
+          position = { x: 0, y: 0 },
+          createdTime,
+          size,
+        }) => (
+          <Meme
+            key={id}
+            imageURL={imageURL}
+            text={text}
+            owner={owner}
+            ownerProfileURL={ownerProfileURL}
+            position={position}
+            size={size}
             memeId={id}
-        />
+          />
+        )
       )}
     </Container>
   );

--- a/src/pages/Main/MemeList/meta.ts
+++ b/src/pages/Main/MemeList/meta.ts
@@ -1,54 +1,86 @@
-import { MEME_WIDTH_BY_SIZE } from '../../../constants';
+import { MEME_WIDTH_BY_SIZE } from "../../../constants";
 
-export const byCreatedTime = (a: Meme, b: Meme) => b.createdTime - a.createdTime;
+export const byCreatedTime = (a: Meme, b: Meme) =>
+  b.createdTime - a.createdTime;
 
-export const formatMemes = (memes: Meme[], memeElements: Element[]) => {
-  const memesWithElements = memes.map((meme, i) => ({ ...meme, element: memeElements[i] }));
-  return memesWithElements.sort(byCreatedTime).map((meme, _, memes) => {
-    return {
-      ...meme,
-      position: findPosition(meme, memes),
-    };
-  });
+export const formatMemes = (
+  memes: Meme[],
+  memeElements: Element[],
+  containerWidth: number
+) => {
+  const memesWithElements = memes.map((meme, i) => ({
+    ...meme,
+    element: memeElements[i],
+  }));
+
+  return memesWithElements.sort(byCreatedTime).map((meme, _, memes) => ({
+    ...meme,
+    position: findPosition(meme, memes, containerWidth),
+  }));
 };
-type MemeWithElement = Meme & { element: Element };
-const SCROLLBAR_WIDTH = 15;
-export const findPosition = (target: MemeWithElement, memes: MemeWithElement[]): Position => {
-  const viewportWidth = window.innerWidth === document.body.scrollWidth ? window.innerWidth : window.innerWidth - SCROLLBAR_WIDTH;
-  const x = arrangeXCoordinate(target.createdTime % viewportWidth, MEME_WIDTH_BY_SIZE[target.size], viewportWidth, memes);
-  const y = arrangeYCoordinate(target);
-  return { x, y };
-}
 
-const RETRY_COUNT_LIMIT = 5;
-const arrangeXCoordinate = (left: number, width: number, max: number, memes: Meme[], retryCount = 0): number => {
-  const right = left + width;
-  const overlapsViewportRight = right > max;
-  const overlapsOthers = memes.some(({ position, size }) => 
-    position
-    && (left < position.x + MEME_WIDTH_BY_SIZE[size] || right > position.x)
+type MemeWithElement = Meme & { element: Element };
+
+export const findPosition = (
+  target: MemeWithElement,
+  memes: MemeWithElement[],
+  containerWidth: number
+): Position => {
+  const x = arrangeXCoordinate(
+    target.createdTime % containerWidth,
+    MEME_WIDTH_BY_SIZE[target.size],
+    containerWidth,
+    memes
   );
 
-  const overlaps = overlapsOthers || overlapsViewportRight;
-  if (overlaps && retryCount < RETRY_COUNT_LIMIT) {
-    let jumpSize = Math.floor(left / 2);
-    if (jumpSize === 0) jumpSize = width;
+  const y = arrangeYCoordinate(target);
 
-    let leftToRetry = left + jumpSize;
-    if (overlapsViewportRight) {
-      leftToRetry = jumpSize;
-    }
+  return { x, y };
+};
+
+const RETRY_COUNT_LIMIT = 5;
+
+const arrangeXCoordinate = (
+  left: number,
+  width: number,
+  max: number,
+  memes: Meme[],
+  retryCount = 0
+): number => {
+  const right = left + width;
+
+  const overlapsOthers = memes.some(({ position, size }) => {
+    if (!position) return false;
+
+    const memeRight = position.x + MEME_WIDTH_BY_SIZE[size];
+
+    return left < memeRight || right > position.x;
+  });
+
+  const overRange = right > max;
+  const needArrage = overlapsOthers || overRange;
+
+  if (needArrage && retryCount < RETRY_COUNT_LIMIT) {
+    const halfLeft = Math.floor(left / 2);
+    const jumpSize = halfLeft === 0 ? width : halfLeft;
+    const leftToRetry = overRange ? left + jumpSize : jumpSize;
+
     return arrangeXCoordinate(leftToRetry, width, max, memes, retryCount + 1);
-  };
+  }
+
   return left;
 };
 
 const SEC = 1000;
 const PX_PER_UNIT_TIME = 1;
+
 const arrangeYCoordinate = (target: MemeWithElement) => {
   const currentTime = new Date().getTime();
-  const yToTime = Math.floor((currentTime - target.createdTime) / SEC) * PX_PER_UNIT_TIME;
-  if (target.element) return yToTime;
-  return 0;
-}
 
+  const yToTime =
+    Math.floor((currentTime - target.createdTime) / SEC) * PX_PER_UNIT_TIME;
+
+  if (target.element) return yToTime;
+
+  return 0;
+};

--- a/src/pages/Main/MemeList/meta.ts
+++ b/src/pages/Main/MemeList/meta.ts
@@ -54,7 +54,7 @@ const arrangeXCoordinate = (
 
     const memeRight = position.x + MEME_WIDTH_BY_SIZE[size];
 
-    return left < memeRight || right > position.x;
+    return left < memeRight && right > position.x;
   });
 
   const overRange = right > max;

--- a/src/pages/Main/MemeList/meta.ts
+++ b/src/pages/Main/MemeList/meta.ts
@@ -49,7 +49,7 @@ const arrangeXCoordinate = (
 ): number => {
   const right = left + width;
 
-  const overlapsOthers = memes.some(({ position, size }) => {
+  const isOverlappedWithOthers = memes.some(({ position, size }) => {
     if (!position) return false;
 
     const memeRight = position.x + MEME_WIDTH_BY_SIZE[size];
@@ -57,13 +57,13 @@ const arrangeXCoordinate = (
     return left < memeRight && right > position.x;
   });
 
-  const overRange = right > max;
-  const needArrage = overlapsOthers || overRange;
+  const isOutOfRange = right > max;
+  const needToArrage = isOverlappedWithOthers || isOutOfRange;
 
-  if (needArrage && retryCount < RETRY_COUNT_LIMIT) {
+  if (needToArrage && retryCount < RETRY_COUNT_LIMIT) {
     const halfLeft = Math.floor(left / 2);
     const jumpSize = halfLeft === 0 ? width : halfLeft;
-    const leftToRetry = overRange ? left + jumpSize : jumpSize;
+    const leftToRetry = isOutOfRange ? left + jumpSize : jumpSize;
 
     return arrangeXCoordinate(leftToRetry, width, max, memes, retryCount + 1);
   }

--- a/src/pages/Main/MemeList/styles.tsx
+++ b/src/pages/Main/MemeList/styles.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
 export default styled.div`
   position: relative;
@@ -6,7 +6,8 @@ export default styled.div`
   height: 100vh;
   max-height: 1800px;
   transition: height 3s linear;
-  
+  overflow: hidden;
+
   &.init {
     transition: none;
     [data-ref="meme"] {

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -9,7 +9,7 @@ import Onboarding from "../../components/Onboarding/Onboarding";
 interface MainProps {}
 
 const Main: React.FC<MainProps> = (props) => {
-  const { memes } = useMemes();
+  const { memesTimeLine } = useMemes();
 
   const getHasOnboarding = localStorage.getItem("hasOnboarding");
   const hasOnboarding = Boolean(getHasOnboarding);
@@ -17,7 +17,7 @@ const Main: React.FC<MainProps> = (props) => {
   return (
     <Layout>
       {!hasOnboarding && <Onboarding />}
-      <MemeList memes={memes} />
+      <MemeList memesTimeLine={memesTimeLine} />
       <UserCard />
       <CreationButton />
     </Layout>

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,39 +1,51 @@
 const typography = {
   heading1: {
     fontSize: 48,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     lineHeight: 1.7,
-    fontStyle: 'normal',
+    fontStyle: "normal",
   },
   heading2: {
     fontSize: 36,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     lineHeight: 1.7,
-    fontStyle: 'normal',
+    fontStyle: "normal",
   },
   heading3: {
     fontSize: 24,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     lineHeight: 1.7,
-    fontStyle: 'normal',
+    fontStyle: "normal",
   },
   heading4: {
     fontSize: 18,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     lineHeight: 1.7,
-    fontStyle: 'normal',
+    fontStyle: "normal",
   },
   body: {
     fontSize: 16,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     lineHeight: 1.6,
-    fontStyle: 'normal',
+    fontStyle: "normal",
   },
-  detail: {
+  detail1: {
     fontSize: 14,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     lineHeight: 1.6,
-    fontStyle: 'normal',
+    fontStyle: "normal",
+  },
+  detail2: {
+    fontSize: 12,
+    fontWeight: "bold",
+    lineHeight: 1.6,
+    fontStyle: "normal",
+  },
+  detail3: {
+    fontSize: 10,
+    fontWeight: "bold",
+    lineHeight: 1.6,
+    fontStyle: "normal",
   },
 } as const;
 


### PR DESCRIPTION
#44 
사이즈(S, M, L) 별로
밈 width, 프로필 이미지, 텍스트 사이즈가 다르게 렌더링 되도록 변경했습니다.

### S 사이즈
<img width="412" alt="스크린샷 2023-08-19 오후 3 21 12" src="https://github.com/memedulecy/frontend/assets/31424628/e2694762-bf3f-4bbc-a5ed-734eb68ea07b">

### M 사이즈
<img width="410" alt="스크린샷 2023-08-19 오후 3 21 28" src="https://github.com/memedulecy/frontend/assets/31424628/0bb40185-ef7f-45b2-9f14-dc8bc11d6a2d">

### L 사이즈
<img width="410" alt="스크린샷 2023-08-19 오후 3 21 46" src="https://github.com/memedulecy/frontend/assets/31424628/aed421d6-59aa-4787-85cc-ef61cf8d7546">
