### PR TITLE
사이즈에 따라 밈 크기 다르게 렌더링

### DIFF
--- a/src/components/Meme/index.tsx
+++ b/src/components/Meme/index.tsx
@@ -1,10 +1,11 @@
-import React, { useMemo } from 'react';
-import Text from '../Text';
-import { DEFALUT_IMAGE } from '../../constants';
-import ProfileImage from '../ProfileImage';
-import Frame, { FloatBox, Footer, MemeFrame } from './styles';
-import { randomInt } from '../../utils/math';
-import { Link } from 'react-router-dom';
+import React, { useMemo } from "react";
+import Text from "../Text";
+import { DEFALUT_IMAGE } from "../../constants";
+import ProfileImage from "../ProfileImage";
+import Frame, { FloatBox, Footer, MemeFrame } from "./styles";
+import { randomInt } from "../../utils/math";
+import { Link } from "react-router-dom";
+import { DefaultTheme } from "styled-components/dist/types";
 
 interface MemeProps {
   imageURL?: string;
@@ -12,7 +13,7 @@ interface MemeProps {
   owner: string;
   ownerProfileURL?: string;
   position: Position;
-  size: Meme['size'];
+  size: Meme["size"];
   memeId: string;
 }
 
@@ -30,26 +31,37 @@ const Meme: React.FC<MemeProps> = ({
     if (hasImage) {
       return <img src={imageURL} alt={text} />;
     } else if (hasText) {
-      return <Text size="detail">{text}</Text>;
+      return <Text size={textSizeMap[size]}>{text}</Text>;
     } else {
       return <img src={DEFALUT_IMAGE} alt={text} />;
     }
-  }, [imageURL, text]);
+  }, [imageURL, text, size]);
 
   const animationDelay = useMemo(() => randomInt(1000, 0, 100), []);
+
   return (
-    <Link to={'/detail'} state={{ memeId }}>
+    <Link to={"/detail"} state={{ memeId }}>
       <Frame data-ref="meme" position={position} size={size}>
         <FloatBox delay={animationDelay}>
           <MemeFrame>{meme}</MemeFrame>
           <Footer>
-            <ProfileImage imageURL={ownerProfileURL} />
-            <Text size="detail">{owner}</Text>
+            <ProfileImage imageURL={ownerProfileURL} size={size} />
+            <Text size={textSizeMap[size]}>{owner}</Text>
           </Footer>
         </FloatBox>
       </Frame>
     </Link>
   );
+};
+
+const textSizeMap: {
+  L: keyof DefaultTheme["typography"];
+  M: keyof DefaultTheme["typography"];
+  S: keyof DefaultTheme["typography"];
+} = {
+  L: "detail1",
+  M: "detail2",
+  S: "detail3",
 };
 
 export default Meme;

--- a/src/components/ProfileImage/index.tsx
+++ b/src/components/ProfileImage/index.tsx
@@ -1,18 +1,25 @@
-import React, { useMemo } from 'react'
-import { DEFALUT__PROFILE_IMAGE } from '../../constants';
-import Frame from './styles';
+import React, { useMemo } from "react";
+import {
+  DEFALUT__PROFILE_IMAGE,
+  MEME_PROFILE_WIDTH_BY_SIZE,
+} from "../../constants";
+import Frame from "./styles";
 
 interface ProfileImageProps {
   imageURL?: string;
+  size: "S" | "M" | "L";
 }
 
-const ProfileImage: React.FC<ProfileImageProps> = ({ imageURL }) => {
-  const image = useMemo(() => imageURL !== undefined ? imageURL : DEFALUT__PROFILE_IMAGE, [imageURL]);
+const ProfileImage: React.FC<ProfileImageProps> = ({ imageURL, size }) => {
+  const image = useMemo(
+    () => (imageURL !== undefined ? imageURL : DEFALUT__PROFILE_IMAGE),
+    [imageURL]
+  );
   return (
-    <Frame>
+    <Frame size={MEME_PROFILE_WIDTH_BY_SIZE[size]}>
       <img src={image} alt="user profile" />
     </Frame>
-  )
-}
+  );
+};
 
 export default ProfileImage;

--- a/src/components/ProfileImage/styles.tsx
+++ b/src/components/ProfileImage/styles.tsx
@@ -1,14 +1,13 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
-export default styled.div`
-  display: inline-block;
-  border-radius: 50%;
-  overflow: hidden;
-  width: 24px;
-  height: 24px;
+export default styled.div<{ size: number }>`
+  width: ${({ size }) => size}px;
+  height: ${({ size }) => size}px;
 
   img {
+    display: block;
     width: 100%;
     height: 100%;
+    border-radius: 50%;
   }
 `;

--- a/src/components/Text/styles.tsx
+++ b/src/components/Text/styles.tsx
@@ -1,33 +1,35 @@
-import styled, { DefaultTheme } from 'styled-components';
-import { typo, themeColor } from '../../utils/style';
+import styled, { DefaultTheme } from "styled-components";
+import { typo, themeColor } from "../../utils/style";
 
 export interface TextStyleProps {
-  size: keyof DefaultTheme['typography'];
+  size: keyof DefaultTheme["typography"];
   type?: keyof typeof typeMap;
-  color?: keyof DefaultTheme['color'];
-};
+  color?: keyof DefaultTheme["color"];
+}
 
 export default styled.span<TextStyleProps>`
   ${({ size }) => typo(size)};
 
   display: ${({ type, size }) => {
     if (type !== undefined) return typeMap[type];
-    switch (size){
-      case 'body':
-      case 'detail':
+    switch (size) {
+      case "body":
+      case "detail1":
+      case "detail2":
+      case "detail3":
         return typeMap.inline;
-      case 'heading1':
-      case 'heading2':
-      case 'heading3':
-      case 'heading4':
+      case "heading1":
+      case "heading2":
+      case "heading3":
+      case "heading4":
         return typeMap.block;
     }
   }};
 
-  color: ${({ color, theme }) => themeColor(color ?? 'text')({ theme })};
+  color: ${({ color, theme }) => themeColor(color ?? "text")({ theme })};
 `;
 
 const typeMap = {
-  inline: 'inline-block',
-  block: 'block',
+  inline: "inline-block",
+  block: "block",
 } as const;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,8 +1,14 @@
-export const DEFALUT_IMAGE = 'https://dummyimage.com/600x400/000/fff';
-export const DEFALUT__PROFILE_IMAGE = 'https://dummyimage.com/600x400/000/fff';
+export const DEFALUT_IMAGE = "https://dummyimage.com/600x400/000/fff";
+export const DEFALUT__PROFILE_IMAGE = "https://dummyimage.com/600x400/000/fff";
 
-export const MEME_WIDTH_BY_SIZE: Record<Meme['size'], number> = {
-  S: 80,
+export const MEME_WIDTH_BY_SIZE: Record<Meme["size"], number> = {
+  S: 100,
   M: 150,
   L: 200,
+};
+
+export const MEME_PROFILE_WIDTH_BY_SIZE: Record<Meme["size"], number> = {
+  S: 16,
+  M: 20,
+  L: 24,
 };

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,39 +1,51 @@
 const typography = {
   heading1: {
     fontSize: 48,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     lineHeight: 1.7,
-    fontStyle: 'normal',
+    fontStyle: "normal",
   },
   heading2: {
     fontSize: 36,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     lineHeight: 1.7,
-    fontStyle: 'normal',
+    fontStyle: "normal",
   },
   heading3: {
     fontSize: 24,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     lineHeight: 1.7,
-    fontStyle: 'normal',
+    fontStyle: "normal",
   },
   heading4: {
     fontSize: 18,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     lineHeight: 1.7,
-    fontStyle: 'normal',
+    fontStyle: "normal",
   },
   body: {
     fontSize: 16,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     lineHeight: 1.6,
-    fontStyle: 'normal',
+    fontStyle: "normal",
   },
-  detail: {
+  detail1: {
     fontSize: 14,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     lineHeight: 1.6,
-    fontStyle: 'normal',
+    fontStyle: "normal",
+  },
+  detail2: {
+    fontSize: 12,
+    fontWeight: "bold",
+    lineHeight: 1.6,
+    fontStyle: "normal",
+  },
+  detail3: {
+    fontSize: 10,
+    fontWeight: "bold",
+    lineHeight: 1.6,
+    fontStyle: "normal",
   },
 } as const;
 


### PR DESCRIPTION
#44 
사이즈(S, M, L) 별로
밈 width, 프로필 이미지, 텍스트 사이즈가 다르게 렌더링 되도록 변경했습니다.

### S 사이즈
<img width="412" alt="스크린샷 2023-08-19 오후 3 21 12" src="https://github.com/memedulecy/frontend/assets/31424628/e2694762-bf3f-4bbc-a5ed-734eb68ea07b">

### M 사이즈
<img width="410" alt="스크린샷 2023-08-19 오후 3 21 28" src="https://github.com/memedulecy/frontend/assets/31424628/0bb40185-ef7f-45b2-9f14-dc8bc11d6a2d">

### L 사이즈
<img width="410" alt="스크린샷 2023-08-19 오후 3 21 46" src="https://github.com/memedulecy/frontend/assets/31424628/aed421d6-59aa-4787-85cc-ef61cf8d7546">
